### PR TITLE
Proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The contract provides an interface to redeem a bounty that was set for Legendre 
 
 # Requirements
 
-This project uses `pipenv`, [https://docs.pipenv.org/en/latest/](https://docs.pipenv.org/en/latest/).
+This project uses `pipenv`, https://docs.pipenv.org/en/latest/.
 
 ## Install
 
@@ -18,7 +18,7 @@ pipenv install
 ## Compile
 
 ```bash
-vyper contract/legendre_bit.vy
+vyper contract/legendre_bounty.vy
 ```
 
 ## Run tests
@@ -26,4 +26,12 @@ vyper contract/legendre_bit.vy
 ```bash
 make test_install
 make test
+```
+
+## Run with gas cost estimates
+
+To enable debug printing, run pytest with extra flags:
+
+```bash
+pipenv run pytest -s -v -k test_legendre_bit_multi
 ```

--- a/contract/legendre_bounty.vy
+++ b/contract/legendre_bounty.vy
@@ -57,7 +57,7 @@ def legendre_bit(input_a: uint256, q: uint256) -> uint256:
     if a == 0:
         return 1
 
-    assert(q > a and q % 2 == 1)
+    assert(q > a and bitwise_and(q, 1) == 1)
 
     e: uint256 = (q - 1) / 2
     b: uint256 = 32
@@ -71,7 +71,7 @@ def legendre_bit(input_a: uint256, q: uint256) -> uint256:
                                 convert(e, bytes32), # Exponent
                                 convert(q, bytes32)  # Modulus
     ), gas=100000, outsize=32), uint256)
-    
+
     if c == q - 1:
         return 0
     return 1

--- a/contract/legendre_bounty.vy
+++ b/contract/legendre_bounty.vy
@@ -83,8 +83,8 @@ def legendre_bit_multi(input_a: uint256, q: uint256, input_n: uint256) -> uint25
     r: uint256 = 0
     n: uint256 = input_n
     for i in range(256):
-        r *= 2
-        r += self.legendre_bit(a, q)
+        r = shift(r, 1)
+        r = bitwise_or(r, self.legendre_bit(a, q))
         a += 1
         n -= 1
         if n == 0:

--- a/tests/test_legendre.py
+++ b/tests/test_legendre.py
@@ -2,7 +2,7 @@ from hashlib import (
     sha256,
 )
 from random import (
-    randint,
+    Random,
 )
 from .utils import (
     jacobi_bit_multi
@@ -20,7 +20,9 @@ PRIMES = [
 #57896044618658097711785492504343953926634992332820282019728792003956564820063
 ]
 
-VALUES = [randint(0, 2**256 - 1) for i in range(10)]
+# Make tests reproducible by setting the RNG seed, for comparing gas costs between runs.
+rng = Random(123)
+VALUES = [rng.randint(0, 2**256 - 1) for i in range(10)]
 
 @pytest.mark.parametrize(
     'value,prime',


### PR DESCRIPTION
Some improvements in the readme and test reproducability, along with gas cost golfing.

The `r = bitwise_or(r, self.legendre_bit(a, q))` seems to be much more valuable than any other bitwise change I made. My guess is that the compiler can pick it up, and move that 1 resulting bit only in when the legendre bit is 1, or something like that. The multiplication right above doesn't seem to save as much.

Here is a comparison of the numbers: https://gist.github.com/protolambda/a1eb8a07f0afb205728a81f288015d18

I wonder if I'm tricking the gas-estimate call somehow, it really seems like a lot for the change I made. Other similar changes in other places don't win as much gas. Either a problem with the vyper stack, or a hot code path that gets optimized well with this change